### PR TITLE
Fix cookie support detection

### DIFF
--- a/src/jquery.collapse.js
+++ b/src/jquery.collapse.js
@@ -135,15 +135,15 @@
     });
 
     // Make sure can we eat cookies without getting into trouble.
-    var cookie = true;
+    var cookie, cookieSupport;
     $(function() {
         try {
             $.cookie('x', 'x', { path: '/', expires: 10 });
         }
         catch(e) {
             cookie = false;
-            $.cookie('x', null);
         }
+
+        cookieSupport = $.fn.collapse.cookieSupport = cookie;
     });
-    var cookieSupport = $.fn.collapse.cookieSupport = cookie;
 })(jQuery);


### PR DESCRIPTION
I didn't want cookie support, so didn't include `jquery.cookie.js`. Without that plugin, lot of errors were show on the console about `$.cookie` not defined.

It was all about cookie support detection. I made some changes to fix it.
