### PR TITLE
Add status classes to main element

### DIFF
--- a/src/jquery.collapse.js
+++ b/src/jquery.collapse.js
@@ -6,36 +6,36 @@
  * Copyright 2010, Daniel Stocks
  * Released under the MIT, BSD, and GPL Licenses.
  */
- 
+
 (function($) {
-    
+
     // Use a cookie counter to allow multiple instances of the plugin
     var cookieCounter = 0;
-    
+
     $.fn.extend({
         collapse: function(options) {
-            
+
             var defaults = {
                 head : "h3",
                 group : "div, ul",
                 cookieName : "collapse",
                 // Default function for showing content
-                show: function() { 
+                show: function() {
                     this.show();
                 },
                 // Default function for hiding content
-                hide: function() { 
+                hide: function() {
                     this.hide();
                 }
             };
             var op = $.extend(defaults, options);
-            
+
             // Default CSS classes
             var active = "active",
                 inactive = "inactive";
-            
+
             return this.each(function() {
-                
+
                 // Increment coookie counter to ensure cookie name integrity
                 cookieCounter++;
                 var obj = $(this),
@@ -47,13 +47,19 @@
                     var panel = obj.find(op.head).map(function() {
                         var head = $(this)
                         if(!head.hasClass(active)) {
+                            obj.removeClass('is-not-collapsed');
+                            obj.addClass('is-collapsed');
                             return head.next(op.group).hide()[0];
                         }
+                        obj.removeClass('is-collapsed');
+                        obj.addClass('is-not-collapsed');
                         return head.next(op.group)[0];
                     });
-    
+
                 // Bind event for showing content
                 obj.bind("show", function(e, bypass) {
+                    $(this).removeClass('is-collapsed');
+                    $(this).addClass('is-not-collapsed');
                     var obj = $(e.target);
                     // ARIA attribute
                     obj.attr('aria-hidden', false)
@@ -70,6 +76,8 @@
 
                 // Bind event for hiding content
                 obj.bind("hide", function(e, bypass) {
+                    $(this).removeClass('is-not-collapsed');
+                    $(this).addClass('is-collapsed');
                     var obj = $(e.target);
                     obj.attr('aria-hidden', true)
                         .prev()
@@ -81,7 +89,7 @@
                         op.hide.call(obj);
                     }
                 });
-                
+
                 // Look for existing cookies
                 if(cookieSupport) {
                     for (var c=0;c<=l;c++) {
@@ -95,7 +103,7 @@
                         }
                     }
                 }
-                
+
                 // Delegate click event to show/hide content.
                 obj.bind("click", function(e) {
                     var t = $(e.target);


### PR DESCRIPTION
Adds CSS classes ("is-collapsed" and "is-not-collapsed") to the root collapsible element. This way we can use it to style our stuff depending on the status of the block (collapsed or not).

I know this could be achieved with `show` and `hide` options, but it's better if its baked in right on the plugin, isn't it? :)
