### PR TITLE
class="open" should not override persist state

### DIFF
--- a/src/jquery.collapse.js
+++ b/src/jquery.collapse.js
@@ -33,8 +33,11 @@
     _this.$el.find(query).each(function() {
       var section = new Section($(this), _this);
       _this.sections.push(section);
-      _this.states[section._index()] || section.$summary.hasClass("open") ?
-        section.open(true) : section.close(true);
+      if (typeof _this.states[section._index()] !== "undefined") {
+        _this.states[section._index()] ? section.open(true) : section.close(true);
+      } else {
+        section.$summary.hasClass("open") ? section.open(true) : section.close(true);
+      }
     });
 
     // Capute ALL the clicks!


### PR DESCRIPTION
Currently, the plugin doesn't distinguish between persist not having a key or having a false value.

What I think should happen is that the truth value of persist should be used if present, otherwise the open class should behave as normal.
