### PR TITLE
Allow the user to customise the click query

### DIFF
--- a/src/jquery.collapse.js
+++ b/src/jquery.collapse.js
@@ -54,7 +54,9 @@
 
     // Capute ALL the clicks!
     (function(scope) {
-      _this.$el.on("click", "[data-collapse-summary]",
+      var clickQuery = scope.options['clickQuery'] || "";
+
+      _this.$el.on("click", "[data-collapse-summary] " + clickQuery,
         $.proxy(_this.handleClick, scope));
     }(_this));
   }
@@ -87,11 +89,12 @@
 
   // Section constructor
   function Section($el, parent) {
+    var summaryElement = $el.attr("data-collapse-summary", "");
+    if(!parent.options['clickQuery']) summaryElement = summaryElement.wrapInner('<a href="#"/>');
+
     $.extend(this, {
       isOpen : false,
-      $summary : $el
-        .attr("data-collapse-summary", "")
-        .wrapInner('<a href="#"/>'),
+      $summary : summaryElement,
       $details : $el.next(),
       options: parent.options,
       parent: parent


### PR DESCRIPTION
Hi !

To be able to integrate jQuery-Collapse on one of my project, I had to customise the element we can click on to collapse a section.

This patch let you define a new option **clickQuery** to select an element in the "Summary" header. To be able to select a specific button instead of the entire header fox example.

Hope this will help

Thank you

Aurélien
