### PR TITLE
Do not apply plugin more than once

### DIFF
--- a/src/jquery.collapse.js
+++ b/src/jquery.collapse.js
@@ -30,7 +30,7 @@
 
     // For every pair of elements in given
     // element, create a section
-    _this.$el.find(query).each(function() {
+    _this.$el.find(query).filter(':not([data-collapse-summary])').each(function() {
       var section = new Section($(this), _this);
       _this.sections.push(section);
 


### PR DESCRIPTION
With this patch jquery-collapse will not apply itself to objects already applied with it. Not sure that filtering "data-collapse-summary" attribute is a good way to find if plugin was applied but it works for me.
