### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "jQuery-Collapse",
+  "version": "1.0.1",
+  "main": "src/jquery.collapse.js",
+  "dependencies": {
+    "jquery": "~1.7"
+  },
+  "ignore": [
+    "demo",
+    "spec",
+    "vendor",
+    "bower.json",
+    "README.md"
+  ]
+}

--- a/component.json
+++ b/component.json
@@ -1,8 +1,0 @@
-{
-  "name": "jQuery-Collapse",
-  "version": "1.0.0",
-  "main": ["./src/jquery.collapse.js"],
-  "dependencies": {
-    "jquery": "~1.7"
-  }
-}


### PR DESCRIPTION
`component.json` is deprecated.

Also ignored unnecessary files that you don't need for installing the plugin via bower.
