### PR TITLE
Moved the exports ahead of DOMReady to enable proper initialization in a RequireJS/TypeScript context

### DIFF
--- a/src/jquery.collapse.js
+++ b/src/jquery.collapse.js
@@ -160,14 +160,14 @@
     }
   });
 
-  //jQuery DOM Ready
-  $(function() {
-    $.fn.collapse(false, true);
-  });
-
   // Expose constructor to
   // global namespace
   exports.jQueryCollapse = Collapse;
   exports.jQueryCollapseSection = Section;
+  
+  //jQuery DOM Ready
+  $(function() {
+    $.fn.collapse(false, true);
+  });
 
 })(window.jQuery, window);


### PR DESCRIPTION
Including v1.1.1 in a RequireJS/TypeScript context always failed with `Uncaught ReferenceError: jQueryCollapseSection is not defined @ jquery.collapse.js:34` because the exports weren't available when a particular constructor call (`new jQueryCollapseSection($(this), _this);`) was made.

Moved up the exports ahead of DOMReady to fix that.