### PR TITLE
Moved up the export to fix an issue with RequireJS/TypeScript-compiled code

### DIFF
--- a/src/jquery.collapse_storage.js
+++ b/src/jquery.collapse_storage.js
@@ -22,11 +22,15 @@
     }
     return DB ? new _Storage(id, DB) : false;
   }
+
   function _Storage(id, DB) {
     this.id = id;
     this.db = DB;
     this.data = [];
   }
+
+  jQueryCollapseStorage = Storage;
+
   _Storage.prototype = {
     write: function(position, state) {
       var _this = this;
@@ -50,7 +54,5 @@
       return string ? JSON.parse(string) : {};
     }
   };
-
-  jQueryCollapseStorage = Storage;
 
 })(jQuery);


### PR DESCRIPTION
This is associated to #81, but happening in the storage code.
It's the same issue: in RequireJS/TypeScript-compiled code the export happens too late and an undefined object is used before it was initialized properly.
